### PR TITLE
Add examples for image resizing and bulk email jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,61 @@ queue.now({ data: 'myJobData' }, 'myJob', 'jobIdentifier', Date.now());
 queue.start();
 ```
 
+### Example 12: Image Resizing and Processing Job Queue
+
+```javascript
+const { PopQueue } = require('pop-queue');
+const sharp = require('sharp');
+
+const queue = new PopQueue('mongodb://localhost:27017', 'redis://localhost:6379', 'myDatabase', 'myCollection', 3);
+
+queue.define('imageResizingJob', async (job) => {
+  console.log('Processing image resizing job:', job);
+  const { inputPath, outputPath, width, height } = job.data;
+  await sharp(inputPath)
+    .resize(width, height)
+    .toFile(outputPath);
+  return true;
+});
+
+queue.now({ inputPath: 'input.jpg', outputPath: 'output.jpg', width: 800, height: 600 }, 'imageResizingJob', 'imageResizingJobIdentifier', Date.now());
+
+queue.start();
+```
+
+### Example 13: Sending Bulk Emails to Users
+
+```javascript
+const { PopQueue } = require('pop-queue');
+const nodemailer = require('nodemailer');
+
+const queue = new PopQueue('mongodb://localhost:27017', 'redis://localhost:6379', 'myDatabase', 'myCollection', 3);
+
+const transporter = nodemailer.createTransport({
+  service: 'gmail',
+  auth: {
+    user: 'your-email@gmail.com',
+    pass: 'your-email-password'
+  }
+});
+
+queue.define('bulkEmailJob', async (job) => {
+  console.log('Processing bulk email job:', job);
+  const { to, subject, text } = job.data;
+  await transporter.sendMail({
+    from: 'your-email@gmail.com',
+    to,
+    subject,
+    text
+  });
+  return true;
+});
+
+queue.now({ to: 'user@example.com', subject: 'Hello', text: 'This is a bulk email.' }, 'bulkEmailJob', 'bulkEmailJobIdentifier', Date.now());
+
+queue.start();
+```
+
 ## Scaling and Performance
 
 To scale the library for millions of users and sessions, consider the following:

--- a/pop-queue/examples/bulk-email.js
+++ b/pop-queue/examples/bulk-email.js
@@ -1,0 +1,28 @@
+const { PopQueue } = require('../queue');
+const nodemailer = require('nodemailer');
+
+const queue = new PopQueue('mongodb://localhost:27017', 'redis://localhost:6379', 'myDatabase', 'myCollection', 3);
+
+const transporter = nodemailer.createTransport({
+  service: 'gmail',
+  auth: {
+    user: 'your-email@gmail.com',
+    pass: 'your-email-password'
+  }
+});
+
+queue.define('bulkEmailJob', async (job) => {
+  console.log('Processing bulk email job:', job);
+  const { to, subject, text } = job.data;
+  await transporter.sendMail({
+    from: 'your-email@gmail.com',
+    to,
+    subject,
+    text
+  });
+  return true;
+});
+
+queue.now({ to: 'user@example.com', subject: 'Hello', text: 'This is a bulk email.' }, 'bulkEmailJob', 'bulkEmailJobIdentifier', Date.now());
+
+queue.start();

--- a/pop-queue/examples/image-resizing.js
+++ b/pop-queue/examples/image-resizing.js
@@ -1,0 +1,17 @@
+const { PopQueue } = require('../queue');
+const sharp = require('sharp');
+
+const queue = new PopQueue('mongodb://localhost:27017', 'redis://localhost:6379', 'myDatabase', 'myCollection', 3);
+
+queue.define('imageResizingJob', async (job) => {
+  console.log('Processing image resizing job:', job);
+  const { inputPath, outputPath, width, height } = job.data;
+  await sharp(inputPath)
+    .resize(width, height)
+    .toFile(outputPath);
+  return true;
+});
+
+queue.now({ inputPath: 'input.jpg', outputPath: 'output.jpg', width: 800, height: 600 }, 'imageResizingJob', 'imageResizingJobIdentifier', Date.now());
+
+queue.start();


### PR DESCRIPTION
Add real-world examples for image resizing and processing job queue, and sending bulk emails to users using the queue system.

* **README.md**
  - Add example for image resizing and processing job queue.
  - Add example for sending bulk emails to users.

* **pop-queue/examples/image-resizing.js**
  - Create a new file for image resizing and processing job queue example.
  - Define a job for image resizing and processing.
  - Enqueue an image resizing job.
  - Start the queue.

* **pop-queue/examples/bulk-email.js**
  - Create a new file for sending bulk emails to users example.
  - Define a job for sending bulk emails.
  - Enqueue a bulk email job.
  - Start the queue.

