### PR TITLE
Add Dockerfile to run the application in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Use the official Node.js image as the base image
+FROM node:14
+
+# Set the working directory
+WORKDIR /usr/src/app
+
+# Copy package.json and package-lock.json
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the application code
+COPY . .
+
+# Expose ports for the REST API and gRPC
+EXPOSE 3000
+EXPOSE 50051
+
+# Set the entry point to start the application
+CMD ["node", "index.js"]

--- a/README.md
+++ b/README.md
@@ -721,3 +721,23 @@ Support for job data schema validation has been added to `pop-queue`. You can va
 ### Built-in Metrics and Monitoring Tools
 
 Built-in metrics and monitoring tools have been introduced to `pop-queue`. You can monitor the performance of your job queues and gather metrics to optimize your system.
+
+## Docker Instructions
+
+### Building the Docker Image
+
+To build the Docker image, run the following command in the root directory of the project:
+
+```bash
+docker build -t pop-queue .
+```
+
+### Running the Docker Container
+
+To run the Docker container, use the following command:
+
+```bash
+docker run -p 3000:3000 -p 50051:50051 pop-queue
+```
+
+This will start the application and expose port 3000 for the REST API and port 50051 for gRPC.


### PR DESCRIPTION
Add a Dockerfile to set up a Node.js environment and update README.md with Docker instructions.

* **Dockerfile**
  - Use the official Node.js image as the base image.
  - Set the working directory to `/usr/src/app`.
  - Copy `package.json` and `package-lock.json` to the working directory.
  - Install dependencies using `npm install`.
  - Copy the application code into the Docker image.
  - Expose port 3000 for the REST API and port 50051 for gRPC.
  - Set the entry point to start the application using `node index.js`.

* **README.md**
  - Add instructions on how to build the Docker image.
  - Add instructions on how to run the Docker container.

