### PR TITLE
Add GitHub Actions workflow to sync wiki

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -1,0 +1,33 @@
+name: Sync Wiki to GitHub Wiki Repository
+
+on:
+  push:
+    paths:
+      - ".github/wiki/**"
+
+jobs:
+  sync-wiki:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Clone Wiki Repository
+        run: |
+          git clone https://github.com/${{ github.repository }}.wiki.git wiki-repo
+
+      - name: Copy Wiki Content
+        run: |
+          cp -r .github/wiki/* wiki-repo/
+
+      - name: Commit and Push Changes
+        run: |
+          cd wiki-repo
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git add .
+          git commit -m "Automated Wiki Sync: $(date)"
+          git push origin main

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 15. [Core Features](#core-features)
 16. [New Features](#new-features)
 17. [Docker Instructions](#docker-instructions)
+18. [Sync Wiki to GitHub Wiki Repository](#sync-wiki-to-github-wiki-repository)
 
 ## Overview
 
@@ -109,3 +110,23 @@ For documentation on new features, including job prioritization and delayed jobs
 ## Docker Instructions
 
 For Docker instructions, including building the Docker image and running the Docker container, please visit the [Docker Instructions](https://github.com/uuuchit/pop-queue/wiki/Docker-Instructions) page in the GitHub wiki.
+
+## Sync Wiki to GitHub Wiki Repository
+
+A new GitHub Actions workflow has been added to sync the contents of the `.github/wiki` directory to the GitHub Wiki repository on push. This workflow ensures that any changes made to the wiki files in the `.github/wiki` directory are automatically reflected in the GitHub Wiki repository.
+
+### Purpose
+
+The purpose of this workflow is to automate the process of syncing the wiki files to the GitHub Wiki repository, ensuring that the documentation is always up-to-date.
+
+### How it Works
+
+The workflow triggers on push to the `.github/wiki` directory. It includes the following steps:
+1. Checkout the main repository.
+2. Clone the GitHub Wiki repository.
+3. Copy files from the `.github/wiki` directory to the wiki repository.
+4. Commit and push changes to the GitHub Wiki repository.
+
+### Instructions
+
+To trigger the workflow, simply push changes to the `.github/wiki` directory. The workflow will automatically run and sync the changes to the GitHub Wiki repository.


### PR DESCRIPTION
Add a new GitHub Actions workflow to sync the contents of the `.github/wiki` directory to the GitHub Wiki repository on push.

* **README.md**
  - Add a section about the new GitHub Actions workflow for syncing the wiki.
  - Mention the purpose of the workflow and how it works.
  - Provide instructions on how to trigger the workflow.

* **.github/workflows/sync-wiki.yml**
  - Create a new GitHub Actions workflow file.
  - Define the trigger for the workflow on push to `.github/wiki` directory.
  - Add steps to checkout the repository.
  - Add steps to clone the GitHub Wiki repository.
  - Add steps to copy files from `.github/wiki` to the wiki repository.
  - Add steps to commit and push changes to the GitHub Wiki repository.

