### PR TITLE
Prepare for npm publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,89 @@ The workflow triggers on push to the `.github/wiki` directory. It includes the f
 ### Instructions
 
 To trigger the workflow, simply push changes to the `.github/wiki` directory. The workflow will automatically run and sync the changes to the GitHub Wiki repository.
+
+## Installation from npm
+
+To install the package from npm, use the following command:
+
+```bash
+npm install pop-queue
+```
+
+## Usage after Installation
+
+After installing the package from npm, you can use it in your project as follows:
+
+```javascript
+const { PopQueue } = require('pop-queue');
+
+const queue = new PopQueue('mongodb://localhost:27017', 'redis://localhost:6379', 'myDatabase', 'myCollection', 3);
+
+queue.define('myJob', async (job) => {
+  console.log('Processing job:', job);
+  // Perform job processing logic here
+  return true;
+});
+
+queue.now({ data: 'jobData' }, 'myJob', 'jobIdentifier', Date.now());
+
+queue.start();
+```
+
+## Contributing to the Package
+
+Thank you for considering contributing to the `pop-queue` project! We welcome contributions from the community to help improve and enhance the library. Please take a moment to review the following guidelines before getting started.
+
+### How to Contribute
+
+1. **Fork the Repository**: Start by forking the `pop-queue` repository to your GitHub account.
+
+2. **Clone the Repository**: Clone the forked repository to your local machine.
+
+   ```bash
+   git clone https://github.com/your-username/pop-queue.git
+   cd pop-queue
+   ```
+
+3. **Create a Branch**: Create a new branch for your contribution. Use a descriptive name for the branch to indicate the purpose of your changes.
+
+   ```bash
+   git checkout -b my-feature-branch
+   ```
+
+4. **Make Changes**: Make your changes to the codebase. Ensure that your changes adhere to the project's coding standards and guidelines.
+
+5. **Write Tests**: If applicable, write tests to cover your changes. Ensure that all existing tests pass.
+
+6. **Commit Changes**: Commit your changes with a descriptive commit message.
+
+   ```bash
+   git add .
+   git commit -m "Add feature X"
+   ```
+
+7. **Push Changes**: Push your changes to your forked repository.
+
+   ```bash
+   git push origin my-feature-branch
+   ```
+
+8. **Create a Pull Request**: Open a pull request (PR) on the original `pop-queue` repository. Provide a clear and concise description of your changes and the problem they solve.
+
+### Code of Conduct
+
+We expect all contributors to adhere to the project's Code of Conduct. Please read and follow the [Code of Conduct](https://github.com/uuuchit/pop-queue/blob/main/CODE_OF_CONDUCT.md) to ensure a positive and inclusive environment for everyone.
+
+### Reporting Issues
+
+If you encounter any issues or bugs while using `pop-queue`, please report them by opening an issue on the GitHub repository. Provide as much detail as possible to help us understand and resolve the issue.
+
+### Feature Requests
+
+We welcome feature requests and suggestions for improvements. If you have an idea for a new feature, please open an issue on the GitHub repository and provide a detailed description of the feature and its benefits.
+
+### Contact
+
+If you have any questions or need further assistance, feel free to reach out to the project maintainers by opening an issue 
+
+Thank you for your contributions and support!

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   },
   "devDependencies": {
     "jest": "^27.0.6"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
Update `package.json` and `README.md` to prepare for npm publishing.

* **package.json**
  - Add `publishConfig` field with `registry` set to `https://registry.npmjs.org/`.

* **README.md**
  - Add a section on how to install the package from npm.
  - Add a section on how to use the package after installation.
  - Add a section on how to contribute to the package.

