### PR TITLE
Add schedule jobs feature

### DIFF
--- a/.github/wiki/New-Features.md
+++ b/.github/wiki/New-Features.md
@@ -129,3 +129,25 @@ console.log('Jobs failed:', metrics.jobsFailed);
 console.log('Jobs succeeded:', metrics.jobsSucceeded);
 console.log('Job duration:', metrics.jobDuration);
 ```
+
+## Example of Delaying Jobs
+
+The `pop-queue` library allows you to delay jobs by specifying a delay in milliseconds. You can use the `now` method to enqueue a job with a delay.
+
+Example:
+
+```javascript
+const { PopQueue } = require('pop-queue');
+
+const queue = new PopQueue('mongodb://localhost:27017', 'redis://localhost:6379', 'myDatabase', 'myCollection', 3);
+
+queue.define('delayedJob', async (job) => {
+  console.log('Processing delayed job:', job);
+  // Perform job processing logic here
+  return true;
+});
+
+queue.now({ data: 'jobData' }, 'delayedJob', 'jobIdentifier', Date.now(), 0, 5000); // Delay 5000ms
+
+queue.start();
+```

--- a/examples/delay-job.js
+++ b/examples/delay-job.js
@@ -1,0 +1,13 @@
+const { PopQueue } = require('pop-queue');
+
+const queue = new PopQueue('mongodb://localhost:27017', 'redis://localhost:6379', 'myDatabase', 'myCollection', 3);
+
+queue.define('delayedJob', async (job) => {
+  console.log('Processing delayed job:', job);
+  // Perform job processing logic here
+  return true;
+});
+
+queue.now({ data: 'jobData' }, 'delayedJob', 'jobIdentifier', Date.now(), 0, 5000); // Delay 5000ms
+
+queue.start();

--- a/examples/schedule-job.js
+++ b/examples/schedule-job.js
@@ -1,0 +1,11 @@
+const { PopQueue } = require('pop-queue');
+
+const queue = new PopQueue('mongodb://localhost:27017', 'redis://localhost:6379', 'myDatabase', 'myCollection', 3);
+
+queue.schedule('myScheduledJob', '0 0 * * *', async () => {
+  console.log('Executing scheduled job');
+  // Perform job logic here
+  return true;
+});
+
+queue.start();

--- a/pop-queue/queue.js
+++ b/pop-queue/queue.js
@@ -721,6 +721,12 @@ class PopQueue extends EventEmitter {
     progress(job, progress) {
         job.progress = progress;
     }
+
+    async schedule(name, cronExpression, jobFunction) {
+        cron.schedule(cronExpression, async () => {
+            await jobFunction();
+        });
+    }
 }
 
 module.exports = {


### PR DESCRIPTION
Add job scheduling and delaying functionality.

* Add `schedule` method in `pop-queue/queue.js` to schedule tasks using cron expressions.
* Add example of delaying jobs in `.github/wiki/New-Features.md`.
* Add `examples/schedule-job.js` to demonstrate scheduling a job using cron expressions.
* Add `examples/delay-job.js` to demonstrate delaying a job.

